### PR TITLE
Music Slash Commands Refactor

### DIFF
--- a/amarbot.py
+++ b/amarbot.py
@@ -139,5 +139,4 @@ if __name__ == "__main__":
             no_utils=args.no_utils,
             no_walls=args.no_walls,
         ),
-        debug=True,
     )

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -47,6 +47,14 @@ class MusicCog(GroupCog, group_name="yt"):
         if guild_id in self.controllers.keys():
             del self.controllers[guild_id]
 
+    async def check_voice(self, interaction: Interaction):
+        ctx = await self.bot.get_context(interaction)
+        if ctx.voice_client is None:
+            return await interaction.response.send_message(
+                "Not connected to a voice channel."
+            )
+        return ctx.voice_client
+
     @app_commands.command()
     @app_commands.describe(
         query='A generic query (e.g. "adele set fire to the rain") or a URL'
@@ -115,14 +123,40 @@ class MusicCog(GroupCog, group_name="yt"):
     @app_commands.describe(volume="Number between 1-100")
     async def volume(self, interaction: Interaction, volume: int):
         """Changes the player's volume."""
+        # TODO: needs to be tested
+        voice_client = await self.check_voice(interaction)
+        if not voice_client:
+            return
+
+        if volume < 1 or volume > 100:
+            return await interaction.response.send_message(
+                "Volume must be a number in the range of 1-100."
+            )
+
+        controller = self.get_controller(interaction)
+        controller.volume = volume / 100
+
+        await interaction.response.send_message(f"Changed volume to {volume}%")
 
     @app_commands.command()
     async def pause(self, interaction: Interaction):
         """Pause the music player."""
+        # TODO: needs to be tested
+        voice_client = await self.check_voice(interaction)
+        if not voice_client:
+            return
+
+        voice_client.pause()
 
     @app_commands.command()
     async def resume(self, interaction: Interaction):
         """Resume the music player."""
+        # TODO: needs to be tested
+        voice_client = await self.check_voice(interaction)
+        if not voice_client:
+            return
+
+        voice_client.resume()
 
     @app_commands.command()
     @app_commands.describe(
@@ -141,6 +175,7 @@ class MusicCog(GroupCog, group_name="yt"):
     @app_commands.command()
     async def next(self, interaction: Interaction):
         """Play the next song in the queue."""
+        # TODO: throws if there is no controller or bot is not in channel
         controller = self.get_controller(interaction)
         controller.next()
         title = controller.current_source.metadata["title"]
@@ -149,6 +184,7 @@ class MusicCog(GroupCog, group_name="yt"):
     @app_commands.command()
     async def back(self, interaction: Interaction):
         """Play the previous song in the queue."""
+        # TODO: throws if there is no controller or bot is not in channel
         controller = self.get_controller(interaction)
         controller.back()
         title = controller.current_source.metadata["title"]

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -17,6 +17,7 @@ from lib.common import join_users_vc
 # TODO: add a /progress command that returns something like this: ...............|........ 2:15 / 3:22
 # TODO: add a /repeat command that repeats songs in a queue or a specific song
 
+
 class MusicCog(GroupCog, group_name="yt"):
     """Commands related to playing music."""
 

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -60,6 +60,8 @@ class MusicCog(GroupCog, group_name="yt"):
         # will take a while
         # TODO: adding a song that already exists in the controller should not be
         # redownloaded
+        # TODO: this command should replace the current playing song, currently it just
+        # adds it to the queue
         controller = self.get_controller(interaction)
         await controller.insert(query)
         source = controller.current_source

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -66,7 +66,9 @@ class MusicCog(GroupCog, group_name="yt"):
     )
     async def play(self, interaction: Interaction, *, query: str):
         """Plays from a query or url (almost anything youtube_dl supports)."""
-        await interaction.response.defer()
+        await interaction.response.send_message(
+            f"Fetching metadata for query: *{query}*"
+        )
 
         # TODO: adding a song that already exists in the controller should not be
         # redownloaded
@@ -83,17 +85,17 @@ class MusicCog(GroupCog, group_name="yt"):
         if voice_client.is_playing():
             voice_client.source = controller
             if isinstance(source, list):
-                await interaction.followup.send(
-                    f"Added a playlist with **{len(source)}** songs to the queue."
+                await interaction.edit_original_response(
+                    content=f"Added a playlist with **{len(source)}** songs to the queue."
                 )
             else:
-                await interaction.followup.send(
-                    f"Added **{source.metadata['title']}** to the queue."
+                await interaction.edit_original_response(
+                    content=f"Added **{source.full_title}** to the queue."
                 )
         else:
             voice_client.play(controller)
-            await interaction.followup.send(
-                f"Now playing **{controller.current_source.metadata['title']}**!"
+            await interaction.edit_original_response(
+                content=f"Now playing **{controller.current_source.source.full_title}**!"
             )
 
     @app_commands.command()

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -1,34 +1,44 @@
 import asyncio
 from typing import List, Optional, Mapping
 
-from discord import Interaction, app_commands
+from discord import Interaction, app_commands, File
 from discord.ext.commands.bot import Bot
 from discord.ext.commands.cog import GroupCog
 
 from lib.logging import get_logger
-from lib.ytdl import YTDLSource
+from lib.ytdl import YTDLSource, YTDLSourcesController
+from lib.common import join_users_vc
 
 
 # TODO: refactor the entire cog to support multiple music controllers for different
 # channels
-# TODO: adjust the controller to download songs instead of streaming them, and
-# intelligently delete the downloaded songs, and predownload songs that are in the
-# queue
+# TODO: adjust the controoler to steam the first song to avoid delays, and download the
+# song in the background at the same time. songs added to a queue should be set to download
+# TODO: add a /progress command that returns something like this: ...............|........ 2:15 / 3:22
+
 class MusicCog(GroupCog, group_name="yt"):
     """Commands related to playing music."""
 
     def __init__(self, bot: Bot) -> None:
-        super().__init__(bot)
+        super().__init__()
 
         self.logger = get_logger(__name__)
         self.logger.debug("Initializing MusicCog...")
 
         self.bot = bot
-        self.controllers: Mapping[str, MusicController] = {}
+        self.controllers: Mapping[str, YTDLSourcesController] = {}
 
     def get_controller(self, interaction: Interaction):
-        # TODO: create the controller if it doesn't exist
-        return self.controllers.get(interaction.guild.id)
+        """Fetch the music controller for the interactions guild, creating it if it
+        doesn't exist.
+        """
+        guild_id = interaction.guild.id
+        controller = self.controllers.get(guild_id)
+        if controller is not None:
+            return controller
+        else:
+            self.controllers[guild_id] = YTDLSourcesController(loop=self.bot.loop)
+            return self.controllers[guild_id]
 
     @app_commands.command()
     @app_commands.describe(
@@ -36,7 +46,35 @@ class MusicCog(GroupCog, group_name="yt"):
     )
     async def play(self, interaction: Interaction, *, query: str):
         """Plays from a query or url (almost anything youtube_dl supports)"""
+        await interaction.response.defer()
+
         controller = self.get_controller(interaction)
+        player = await controller.insert(query)
+        await controller.wait_for_ready_state()
+
+        voice_client = await join_users_vc(self.bot, interaction)
+        voice_client.play(controller)
+
+        await interaction.followup.send(f"Now playing {player.metadata['title']}!")
+
+    @app_commands.command()
+    async def grab(self, interaction: Interaction):
+        """Sends a downloadable mp3 of the current playing song to the channel."""
+        await interaction.response.defer()
+
+        controller = self.get_controller(interaction)
+        source = controller.current_source
+
+        if source is None:
+            await interaction.followup.send("There is no song currently playing")
+            return
+
+        # await interaction.followup.send("waiting for song to finish downloading...")
+        await source.wait_for_download_ready_state()
+        # await interaction.followup.edit_message("converting song to mp3...")
+        filename = await source.write_buffer_to_file()
+
+        await interaction.followup.send(file=File(filename))
 
     @app_commands.command()
     @app_commands.describe(volume="Number between 1-100")
@@ -95,6 +133,14 @@ class MusicCog(GroupCog, group_name="yt"):
     )
     async def mp3(self, interaction: Interaction, query: str):
         """Send an mp3 download link to the channel."""
+        await interaction.response.defer()
+        # source = await YTDLSource.from_url(query, loop=self.bot.loop, stream=False)
+        # player = YTPlayer(query, loop=self.bot.loop)
+        # await player.wait_for_ready_state()
+        # print("player ready!")
+        # print(await player.download())
+        # print("download finished")
+        await interaction.followup.send(f"Here's yo file dawg:")
 
     @app_commands.command()
     @app_commands.describe(
@@ -102,44 +148,3 @@ class MusicCog(GroupCog, group_name="yt"):
     )
     async def mp4(self, interaction: Interaction, query: str):
         """Send an mp4 download link to the channel."""
-
-
-class MusicController:
-    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
-        self.logger = get_logger(__name__)
-        self.logger.debug("Initializing MusicController...")
-
-        self.queue: List[YTDLSource] = []
-
-    def pause(self):
-        """Pauses the current playing song."""
-        self.ctx.voice_client.pause()
-
-    def resume(self):
-        """Resumes the current playing song."""
-        self.ctx.voice_client.resume()
-
-    def insert(self, url: str):
-        """Insert a url into the first position of the queue, effectively making it the
-        next song to be played.
-        """
-        try:
-            self.queue.insert(0, url)
-        except IndexError:
-            self.push(url)
-
-    def push(self, url: str):
-        """Insert a url into the queue"""
-        # instead of holding the player in memory until it gets played, just add
-        # the title so we can regrab it later, since youtube invalidates the links
-        # after some time
-        self.queue.append(url)
-
-    def pop(self, index: int):
-        """Remove a song from the queue and return the name."""
-        return self.queue.pop(index)
-
-    def skip(self):
-        """Skip the currently playing song and schedule the next one in the queue."""
-        self.ctx.voice_client.stop()
-        # self.queue.pop(0)

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -49,14 +49,18 @@ class MusicCog(GroupCog, group_name="yt"):
         """Plays from a query or url (almost anything youtube_dl supports)"""
         await interaction.response.defer()
 
+        # TODO: before we fetch the query, we should parse the URL and see if it's a
+        # playlist, and update the chat with something like: this is a playlist, this
+        # will take a while
         controller = self.get_controller(interaction)
-        player = await controller.insert(query)
+        await controller.insert(query)
+        source = controller.current_source
         await controller.wait_for_ready_state()
 
         voice_client = await join_users_vc(self.bot, interaction)
         voice_client.play(controller)
 
-        await interaction.followup.send(f"Now playing {player.metadata['title']}!")
+        await interaction.followup.send(f"Now playing {source.metadata['title']}!")
 
     @app_commands.command()
     async def grab(self, interaction: Interaction):
@@ -107,10 +111,14 @@ class MusicCog(GroupCog, group_name="yt"):
     @app_commands.command()
     async def next(self, interaction: Interaction):
         """Play the next song in the queue."""
+        controller = self.get_controller(interaction)
+        controller.next()
 
     @app_commands.command()
     async def back(self, interaction: Interaction):
         """Play the previous song in the queue."""
+        controller = self.get_controller(interaction)
+        controller.back()
 
     @app_commands.command()
     async def stop(self, interaction: Interaction):

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -91,6 +91,7 @@ class MusicCog(GroupCog, group_name="yt"):
         self.delete_controller(interaction)
 
         await voice_client.disconnect()
+        voice_client.cleanup()
 
         await interaction.response.send_message("Goodbye!")
 

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -205,11 +205,26 @@ class MusicCog(GroupCog, group_name="yt"):
         await interaction.response.send_message(f"Resumed!")
 
     @app_commands.command()
-    @app_commands.describe(
-        query='A generic query (e.g. "adele set fire to the rain") or a URL'
-    )
-    async def queue(self, interaction: Interaction, *, query: Optional[str] = None):
-        """Add a song to the queue. If no url is provided, shows the current queue."""
+    async def queue(self, interaction: Interaction):
+        """Shows the current music queue."""
+        voice_client = await self.ensure_voice(interaction)
+        if not voice_client:
+            return
+
+        controller = self.get_controller(interaction)
+
+        if len(controller.sources) == 0:
+            await interaction.response.send_message("No songs in the queue.")
+            return
+        else:
+            list_str = "Songs in the current queue:\n"
+            for index, source in enumerate(controller.sources):
+                if index == controller.current_source_index:
+                    list_str += f"> {index + 1}. **{source.full_title}**\n"
+                else:
+                    list_str += f"> {index + 1}. {source.full_title}\n"
+
+            await interaction.response.send_message(list_str.strip())
 
     @app_commands.describe(
         index="Number index of the song you want to remove from the queue"

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -115,7 +115,7 @@ class MusicCog(GroupCog, group_name="yt"):
         controller = self.get_controller(interaction)
         controller.next()
         title = controller.current_source.metadata["title"]
-        interaction.response.send_message(f"Now playing *{title}*!")
+        await interaction.response.send_message(f"Now playing *{title}*!")
 
     @app_commands.command()
     async def back(self, interaction: Interaction):
@@ -123,7 +123,7 @@ class MusicCog(GroupCog, group_name="yt"):
         controller = self.get_controller(interaction)
         controller.back()
         title = controller.current_source.metadata["title"]
-        interaction.response.send_message(f"Now playing *{title}*!")
+        await interaction.response.send_message(f"Now playing *{title}*!")
 
     @app_commands.command()
     async def stop(self, interaction: Interaction):

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -10,10 +10,6 @@ from lib.ytdl import YTDLSource, YTDLSourcesController
 from lib.common import join_users_vc
 
 
-# TODO: refactor the entire cog to support multiple music controllers for different
-# channels
-# TODO: adjust the controoler to steam the first song to avoid delays, and download the
-# song in the background at the same time. songs added to a queue should be set to download
 # TODO: add a /progress command that returns something like this: ...............|........ 2:15 / 3:22
 # TODO: add a /repeat command that repeats songs in a queue or a specific song
 

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -53,6 +53,8 @@ class MusicCog(GroupCog, group_name="yt"):
         # TODO: before we fetch the query, we should parse the URL and see if it's a
         # playlist, and update the chat with something like: this is a playlist, this
         # will take a while
+        # TODO: adding a song that already exists in the controller should not be
+        # redownloaded
         controller = self.get_controller(interaction)
         await controller.insert(query)
         source = controller.current_source

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -232,6 +232,31 @@ class MusicCog(GroupCog, group_name="yt"):
     @app_commands.command()
     async def pop(self, interaction: Interaction, *, index: Optional[int] = None):
         """Remove a song from the queue at index (default last)."""
+        voice_client = await self.ensure_voice(interaction)
+        if not voice_client:
+            return
+
+        controller = self.get_controller(interaction)
+
+        if len(controller.sources) == 0:
+            await interaction.response.send_message("No songs in the queue.")
+            return
+        elif isinstance(index, int) and index < 1:
+            await interaction.response.send_message(f"Index must be higher than 0.")
+            return
+        elif isinstance(index, int) and index > len(controller.sources):
+            await interaction.response.send_message(
+                f"No song in the queue at position {index}."
+            )
+            return
+
+        if isinstance(index, int):
+            index = index - 1
+
+        source = controller.pop(index)
+        await interaction.response.send_message(
+            f"Removed **{source.full_title}** from the queue."
+        )
 
     @app_commands.command()
     async def next(self, interaction: Interaction):

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -81,17 +81,18 @@ class MusicCog(GroupCog, group_name="yt"):
     async def stop(self, interaction: Interaction):
         """Stops the player and disconnects the bot from voice."""
         self.logger.debug(f"Stopping the music player in {interaction.guild.name}...")
-        await interaction.response.defer()
 
-        ctx = await self.bot.get_context(interaction)
-        if ctx.voice_client:
-            await ctx.voice_client.disconnect()
+        voice_client = await self.check_voice(interaction)
+        if not voice_client:
+            return
 
         controller = self.get_controller(interaction)
         controller.cleanup()
         self.delete_controller(interaction)
 
-        await interaction.followup.send("Goodbye!")
+        await voice_client.disconnect()
+
+        await interaction.response.send_message("Goodbye!")
 
     @app_commands.command()
     async def grab(self, interaction: Interaction):

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -119,7 +119,6 @@ class MusicCog(GroupCog, group_name="yt"):
     @app_commands.describe(volume="Number between 1-100")
     async def volume(self, interaction: Interaction, volume: int):
         """Changes the player's volume."""
-        # TODO: needs to be tested
         voice_client = await self.check_voice(interaction)
         if not voice_client:
             return

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -137,22 +137,24 @@ class MusicCog(GroupCog, group_name="yt"):
     @app_commands.command()
     async def pause(self, interaction: Interaction):
         """Pause the music player."""
-        # TODO: needs to be tested
         voice_client = await self.check_voice(interaction)
         if not voice_client:
             return
 
         voice_client.pause()
 
+        await interaction.response.send_message(f"Paused!")
+
     @app_commands.command()
     async def resume(self, interaction: Interaction):
         """Resume the music player."""
-        # TODO: needs to be tested
         voice_client = await self.check_voice(interaction)
         if not voice_client:
             return
 
         voice_client.resume()
+
+        await interaction.response.send_message(f"Resumed!")
 
     @app_commands.command()
     @app_commands.describe(

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -113,12 +113,16 @@ class MusicCog(GroupCog, group_name="yt"):
         """Play the next song in the queue."""
         controller = self.get_controller(interaction)
         controller.next()
+        title = controller.current_source.metadata["title"]
+        interaction.response.send_message(f"Now playing *{title}*!")
 
     @app_commands.command()
     async def back(self, interaction: Interaction):
         """Play the previous song in the queue."""
         controller = self.get_controller(interaction)
         controller.back()
+        title = controller.current_source.metadata["title"]
+        interaction.response.send_message(f"Now playing *{title}*!")
 
     @app_commands.command()
     async def stop(self, interaction: Interaction):

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -202,20 +202,40 @@ class MusicCog(GroupCog, group_name="yt"):
     @app_commands.command()
     async def next(self, interaction: Interaction):
         """Play the next song in the queue."""
-        # TODO: throws if there is no controller or bot is not in channel
+        voice_client = await self.check_voice(interaction)
+        if not voice_client:
+            return
+
         controller = self.get_controller(interaction)
+
+        if controller.current_source_index + 2 > len(controller.sources):
+            await interaction.response.send_message("No next song in the queue.")
+            return
+
         controller.next()
-        title = controller.current_source.metadata["title"]
-        await interaction.response.send_message(f"Now playing *{title}*!")
+
+        await interaction.response.send_message(
+            f"Now playing *{controller.current_source.metadata['title']}*!"
+        )
 
     @app_commands.command()
     async def back(self, interaction: Interaction):
         """Play the previous song in the queue."""
-        # TODO: throws if there is no controller or bot is not in channel
+        voice_client = await self.check_voice(interaction)
+        if not voice_client:
+            return
+
         controller = self.get_controller(interaction)
+
+        if controller.current_source_index - 1 < 0:
+            await interaction.response.send_message("No previous song.")
+            return
+
         controller.back()
-        title = controller.current_source.metadata["title"]
-        await interaction.response.send_message(f"Now playing *{title}*!")
+
+        await interaction.response.send_message(
+            f"Now playing *{controller.current_source.metadata['title']}*!"
+        )
 
     @app_commands.command()
     async def scrub(self, interaction: Interaction):

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -15,6 +15,7 @@ from lib.common import join_users_vc
 # TODO: adjust the controoler to steam the first song to avoid delays, and download the
 # song in the background at the same time. songs added to a queue should be set to download
 # TODO: add a /progress command that returns something like this: ...............|........ 2:15 / 3:22
+# TODO: add a /repeat command that repeats songs in a queue or a specific song
 
 class MusicCog(GroupCog, group_name="yt"):
     """Commands related to playing music."""

--- a/lib/cogs/music.py
+++ b/lib/cogs/music.py
@@ -95,7 +95,7 @@ class MusicCog(GroupCog, group_name="yt"):
         else:
             voice_client.play(controller)
             await interaction.edit_original_response(
-                content=f"Now playing **{controller.current_source.source.full_title}**!"
+                content=f"Now playing **{controller.current_source.full_title}**!"
             )
 
     @app_commands.command()

--- a/lib/ytdl.py
+++ b/lib/ytdl.py
@@ -350,7 +350,7 @@ class YTDLSource(discord.PCMVolumeTransformer):
         """
         self.download_task = self.loop.create_task(self._start_download())
 
-    async def _start_download(self, _retry_attempt = 0):
+    async def _start_download(self, _retry_attempt=0):
         """Long running coroutine that starts downloading bytes from the audio source
         and keeps them in an internal buffer. Updates internal `is_stream_ready` state
         to `True` once the buffer has more than 1 second of audio data, and
@@ -399,7 +399,7 @@ class YTDLSource(discord.PCMVolumeTransformer):
             await self._start_download(_retry_attempt + 1)
         elif len(self._audio_buffer) == 0 and _retry_attempt == max_retries:
             logger.exception(
-                f"failed to download \"{title}\" after {_retry_attempt} retries"
+                f'failed to download "{title}" after {_retry_attempt} retries'
             )
             raise Exception("Failed to download any audio data from the source")
 

--- a/lib/ytdl.py
+++ b/lib/ytdl.py
@@ -284,7 +284,7 @@ class YTDLSource(discord.PCMVolumeTransformer):
 
     @property
     def is_livestream(self):
-        return self.metadata["is_live"]
+        return self.metadata.get("is_live", False)
 
     @classmethod
     def from_file(cls, filename: str | BufferedIOBase):

--- a/lib/ytdl.py
+++ b/lib/ytdl.py
@@ -87,6 +87,16 @@ class YTDLSource(discord.PCMVolumeTransformer):
         return f"{artist} - {title}".strip()
 
     @property
+    def duration(self):
+        """Total audio source duration (in seconds)."""
+        return self.metadata["duration"]
+
+    @property
+    def buffer_duration(self):
+        """Total duration of the audio source loaded in the buffer (in milliseconds)."""
+        return len(self._audio_buffer) * 20
+
+    @property
     def is_downloading(self) -> bool:
         return not self.download_task is None
 
@@ -472,6 +482,22 @@ class YTDLSourcesController(discord.AudioSource):
     def back(self):
         """Sets the current source index to the next source in the queue."""
         self.current_source_index -= 1
+
+    def seek(self, time: int):
+        """Goes forward/backward to a specified time in the current source."""
+        # TODO: finish implementing this
+        raise NotImplementedError()
+
+    def scrub(self, time: int):
+        """Goes forward/backward in the current source by `scrub_amount` (in seconds)."""
+        # "indexes" here is referring to each index in the audio buffer
+        # each index in the buffer contains bytes representing 20ms worth of audio data
+        time_ms = time * 1000
+        skip_indexes = round(time_ms / 20)
+        total_indexes = len(self.current_source._audio_buffer) - 1
+        current_index = self.current_source._audio_buffer_index
+        new_index = max(0, min(current_index + skip_indexes, total_indexes))
+        self.current_source._audio_buffer_index = int(new_index)
 
     async def wait_for_ready_state(self):
         """Coroutine that resolves when the source is ready to start streaming."""

--- a/lib/ytdl.py
+++ b/lib/ytdl.py
@@ -286,6 +286,10 @@ class YTDLSource(discord.PCMVolumeTransformer):
     def is_livestream(self):
         return self.metadata.get("is_live", False)
 
+    @property
+    def to_bytes(self):
+        return b"".join(self._audio_buffer)
+
     @classmethod
     def from_file(cls, filename: str | BufferedIOBase):
         return cls(
@@ -438,7 +442,7 @@ class YTDLSource(discord.PCMVolumeTransformer):
             )
             raise Exception("Failed to download any audio data from the source")
 
-        total_bytes = len(b"".join(self._audio_buffer))
+        total_bytes = len(self.to_bytes)
         self.is_download_ready = True
 
         end_time = perf_counter()
@@ -469,7 +473,7 @@ class YTDLSource(discord.PCMVolumeTransformer):
         logger.debug(f"Saving to {filename}")
 
         segment = AudioSegment(
-            b"".join(self._audio_buffer),
+            self.to_bytes,
             sample_width=2,
             frame_rate=48000,
             channels=2,

--- a/lib/ytdl.py
+++ b/lib/ytdl.py
@@ -435,9 +435,7 @@ class YTDLSourcesController(discord.AudioSource):
     def append(self, source: YTDLSource | List[YTDLSource]):
         """Appends a `YTDLSource` or a list of `YTDLSource` to the end of the queue."""
         if isinstance(source, list):
-            logger.debug(
-                f"Adding a playlist with {len(source)} songs to the queue..."
-            )
+            logger.debug(f"Adding a playlist with {len(source)} songs to the queue...")
             self.sources.extend(source)
         else:
             logger.debug(f"Adding {source.metadata['title']} songs to the queue...")
@@ -446,12 +444,9 @@ class YTDLSourcesController(discord.AudioSource):
         self._prefetch_sources_audio_data()
 
     def insert(self, index: int, source: YTDLSource | List[YTDLSource]):
-        """Inserts a `YTDLSource` or a list of `YTDLSource` before the specified index.
-        """
+        """Inserts a `YTDLSource` or a list of `YTDLSource` before the specified index."""
         if isinstance(source, list):
-            logger.debug(
-                f"Adding a playlist with {len(source)} songs to the queue..."
-            )
+            logger.debug(f"Adding a playlist with {len(source)} songs to the queue...")
             for i, src in enumerate(source):
                 self.sources.insert(index + i, src)
         else:

--- a/lib/ytdl.py
+++ b/lib/ytdl.py
@@ -53,21 +53,33 @@ class YTDLSourcesController(discord.AudioSource):
     to read from them, cycling them as the sources get exhausted.
     """
 
+    # number of songs to in the queue ahead of the current source to download ahead of
+    # time
+    n_songs_loaded = 1
+
     # number of seconds before and after the track to fade in/out the audio
     audio_fade_time = 5.0
 
     # TODO: add a user defined volume and fade in/out to that volume instead of 1
-    def __init__(self, volume: float = 1.0, *, loop: asyncio.AbstractEventLoop) -> None:
+    def __init__(
+        self,
+        volume: float = 1.0,
+        *,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
         self._volume = volume
         self.loop = loop or asyncio.get_event_loop()
 
         self.sources: List[YTDLSource] = []
         self.current_source_index = 0
 
+        # TODO: add a forever-running task that clears audio buffers from out-of-range
+        # sources to save memory
+
     @property
     def is_ready(self):
         """Checks if the current source is stream-ready."""
-        source =  self.current_source
+        source = self.current_source
         if source is None or not source.is_stream_ready:
             return False
         return True
@@ -97,19 +109,30 @@ class YTDLSourcesController(discord.AudioSource):
     async def insert(self, query: str):
         """Instantiates a `YTDLSource` from a query and adds it to the queue."""
         new_source = await YTDLSource.from_query(query, loop=self.loop)
-        self.sources.append(new_source)
+
+        if isinstance(new_source, list):
+            logger.debug(
+                f"Adding a playlist with {len(new_source)} songs to the queue..."
+            )
+            self.sources.extend(new_source)
+        else:
+            logger.debug(f"Adding {new_source.metadata['title']} songs to the queue...")
+            self.sources.append(new_source)
+
+        self._prefetch_sources_audio_data()
+
         return new_source
 
     # def pop(self, index: int):
     #     """Remove a source from the queue."""
 
-    # def next(self):
-    #     """Sets the current source index to the next source in the queue."""
-    #     self.current_source_index += 1
+    def next(self):
+        """Sets the current source index to the next source in the queue."""
+        self.current_source_index += 1
 
-    # def back(self):
-    #     """Sets the current source index to the next source in the queue."""
-    #     self.current_source_index -= 1
+    def back(self):
+        """Sets the current source index to the next source in the queue."""
+        self.current_source_index -= 1
 
     async def wait_for_ready_state(self):
         """Coroutine that resolves when the source is ready to start streaming."""
@@ -125,7 +148,7 @@ class YTDLSourcesController(discord.AudioSource):
         source = self.current_source
 
         if source is None:
-            return b""        
+            return b""
 
         if not self.is_ready:
             return AudioSegment.silent(duration=20, frame_rate=48000).raw_data
@@ -158,6 +181,18 @@ class YTDLSourcesController(discord.AudioSource):
 
         return source.read()
 
+    def _prefetch_sources_audio_data(self):
+        """Prefetches and downloads audio data from upcoming sources before they're
+        needed.
+        """
+        min_index = self.current_source_index
+        max_index = self.current_source_index + self.n_songs_loaded
+
+        for source in self.sources[min_index:max_index]:
+            if source.download_task is None:
+                logger.debug(f"Pre-downloading {source.metadata['title']}...")
+                source.start_download()
+
 
 class YTDLSource(discord.PCMVolumeTransformer):
     """Wrapper over `discord.PCMVolumeTransformer` for the purpose of keeping audio data
@@ -165,38 +200,37 @@ class YTDLSource(discord.PCMVolumeTransformer):
     client at the same time, without needing to fetch from YouTube twice.
     """
 
+    # TODO: check to see if this works with non-youtube URLs
+    # TODO: add download error retries
     # TODO: programmed this in mind that download functionality will always be used,
-    # but should check to make it still works even without it
-    # NOTE: because of the way we built this, it'll also be possible to detect any
-    # issues with the stream before the bytes are actually getting read, so we have a
-    # chance to repair audio streams and continue downloading if we only get like half
-    # way through a download and an error occurs
+    # but should check to make it still works even without it (should also check to see
+    # if it works with or without metadata)
+    # TODO: we should also see what happens to songs in a playlist that have
+    # been removed or deleted
+
     def __init__(
         self,
         source: discord.FFmpegPCMAudio,
         *,
+        metadata: Mapping[str, Any] = None,
         volume=1.0,
         loop: asyncio.AbstractEventLoop = None,
-        metadata: Mapping[str, Any] = None,
-        download=False,
     ):
         super().__init__(source, volume)
         self.source = source
-        self.loop = loop or asyncio.get_event_loop()
         self.metadata = metadata
+        self.loop = loop or asyncio.get_event_loop()
         self.is_stream_ready = False
         self.is_download_ready = False
         self._audio_buffer: List[bytes] = []
         self._audio_buffer_index = -1
+        self.download_task = None
 
-        if download:
-            self.download_task = self.loop.create_task(self.start_download())
-
-    @classmethod
-    async def from_query(
-        cls, query: str, *, loop: asyncio.AbstractEventLoop = None, download=True
-    ):
-        """Instantiate `YTDLSource` from a generic query or URL."""
+    @staticmethod
+    async def from_query(query: str, *, loop: asyncio.AbstractEventLoop = None):
+        """Instantiate and return a single `YTDLSource` (or a list of `YTDLSource` if
+        the query results in an extracted playlist) from a generic query or URL.
+        """
         logger.debug(f"Fetching metadata for query: {query}")
         start_time = perf_counter()
 
@@ -205,20 +239,43 @@ class YTDLSource(discord.PCMVolumeTransformer):
         data = await loop.run_in_executor(
             None, lambda: ytdl.extract_info(query, download=False)
         )
-        if "entries" in data:
-            data = data["entries"][0]
 
         end_time = perf_counter()
         logger.debug(
-            f"Fetched metadata for query: {query} (took {end_time - start_time:0.2f} seconds)"
+            f"Fetched metadata for query: {query} (took {end_time - start_time:0.2f} "
+            "seconds)"
         )
 
-        return cls(
-            discord.FFmpegPCMAudio(data["url"], **ffmpeg_options),
-            loop=loop,
-            metadata=data,
-            download=download
-        )
+        data_type = data.get("_type")
+
+        if data_type == "playlist":
+            entries = data.get("entries")
+
+            if entries is None:
+                # NOTE: ytdl throws an exception
+                err_msg = "ytdl returned a playlist extraction with no entries"
+                raise Exception(err_msg)
+
+            return [
+                YTDLSource(
+                    discord.FFmpegPCMAudio(entry["url"], **ffmpeg_options),
+                    metadata=entry,
+                    loop=loop,
+                )
+                for entry in entries
+            ]
+        elif data_type is None:
+            if "entries" in data:
+                data = data["entries"][0]
+
+            return YTDLSource(
+                discord.FFmpegPCMAudio(data["url"], **ffmpeg_options),
+                metadata=data,
+                loop=loop,
+            )
+        else:
+            err_msg = f"Got unexpected return from ytdl extraction:\n{data}"
+            raise Exception(err_msg)
 
     @classmethod
     def from_file(cls, filename: str | BufferedIOBase):
@@ -238,12 +295,29 @@ class YTDLSource(discord.PCMVolumeTransformer):
             await asyncio.sleep(0)
         return True
 
-    async def start_download(self):
+    def start_download(self):
         """Long running coroutine that starts downloading bytes from the audio source
         and keeps them in an internal buffer. Updates internal `is_stream_ready` state
         to `True` once the buffer has more than 1 second of audio data, and
         `is_download_ready` state to `True` once the audio has been fully downloaded.
         """
+        self.download_task = self.loop.create_task(self._start_download())
+
+    async def _start_download(self):
+        """Long running coroutine that starts downloading bytes from the audio source
+        and keeps them in an internal buffer. Updates internal `is_stream_ready` state
+        to `True` once the buffer has more than 1 second of audio data, and
+        `is_download_ready` state to `True` once the audio has been fully downloaded.
+        """
+
+        # TODO: URL links get invalidated after some time, so we'll want to implement
+        # some sort download retry / metadata refetch functionality
+        # TODO: add a check in here to see when the expiration is for the current source
+        # if it's outdated, attempting a download is pointless and we should refetch the
+        # metadata (the expiration time is usually a couple of hours, but this will be
+        # the case for huge playlists added where the source might not get read for a
+        # very long time)
+
         title = self.metadata["title"]
         logger.debug(f"Starting download for: {title}")
         start_time = perf_counter()
@@ -275,7 +349,7 @@ class YTDLSource(discord.PCMVolumeTransformer):
         """Prepares a linux filesystem-compatible filename to be used by the current
         source download.
         """
-        title = self.metadata['title'].replace("/", "")
+        title = self.metadata["title"].replace("/", "")
         return title
 
     async def write_buffer_to_file(self, filename: str = None) -> str:
@@ -287,7 +361,7 @@ class YTDLSource(discord.PCMVolumeTransformer):
 
         # NOTE: only replacing the '/' character since that is the only restricted
         # filename character on Linux
-        title = self.metadata['title']
+        title = self.metadata["title"]
         filename = filename or f"downloads/{title.replace('/', '')}.mp3"
         logger.debug(f"Saving to {filename}")
 

--- a/lib/ytdl.py
+++ b/lib/ytdl.py
@@ -1,11 +1,31 @@
-import youtube_dl, discord, asyncio
+import asyncio
+import audioop
+import math
+from io import BufferedIOBase, BytesIO
+from time import perf_counter
+from typing import Any, List, Mapping
+
+import discord
+import youtube_dl
+from pydub import AudioSegment
+
+from lib.logging import get_logger
 
 # suppress noise about console usage from errors
 youtube_dl.utils.bug_reports_message = lambda: ""
 
-ytdl_format_options = {
-    "format": "bestaudio/best",
-    "outtmpl": "%(extractor)s-%(id)s-%(title)s.%(ext)s",
+YTDL_FORMAT_BESTAUDIO = "bestaudio/best"
+
+# download best mp3 format available (fails if there isnt one available)
+YTDL_FORMAT_BESTAUDIO_MP3 = "bestaudio[ext=mp3]"
+# download best mp3 format available or any other best if no mp3 is available
+YTDL_FORMAT_BESTAUDIO_MP3 = "bestaudio[ext=mp3]/bestaudio/best"
+# download best mp4 format available or any other best if no mp4 available
+YTDL_FORMAT_BESTAUDIO_MP4 = "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best"
+
+YTDL_FORMAT_OPTIONS = {
+    "format": YTDL_FORMAT_BESTAUDIO_MP3,
+    "outtmpl": "downloads/audio-%(title)s-%(id)s.%(ext)s",
     "restrictfilenames": True,
     # "noplaylist": True,
     "nocheckcertificate": True,
@@ -18,34 +38,192 @@ ytdl_format_options = {
     "source_address": "0.0.0.0",
 }
 
+# ffmpeg -vn option disables video
 ffmpeg_options = {"options": "-vn"}
 
-ytdl = youtube_dl.YoutubeDL(ytdl_format_options)
+logger = get_logger(__name__)
+
+
+# TODO: we want to make a spotify sort of fading in/out effect when songs change, to do
+# this, we'll need to have one audio stream that has seamless bytes streaming, so the queue,
+# would have to be built into some class that handles reading bytes from various audio
+# sources, and writes bytes to one audio stream
+class YTDLSourcesManager:
+    # number of seconds before and after the track to fade in/out the audio
+    audio_fade_seconds = 5
+
+    # TODO: add a user defined volume and fade in/out to that volume instead of 1
+    def __init__(self) -> None:
+        self.sources: List[YTDLSource] = []
+        self.current_source_index = 0
+        self.is_ready = False
+
+    def read(self):
+        if not self.is_ready:
+            raise Exception("stream not yet ready")
+
+        source = self.sources[self.current_source_index]
+        time_elapsed = source.get_time_elapsed()
+        time_remaining = source.get_time_remaining()
+        # TODO: add volume fade in/out
+        # TODO: add source transitions
+        # if time_remaining <= 5.0:
+        #     self.current_source_index += 1
+        #     source = self.sources[self.current_source_index]
+
+        return source.read()
 
 
 class YTDLSource(discord.PCMVolumeTransformer):
-    def __init__(self, source, *, data, volume=1.0):
+    """Wrapper over `discord.PCMVolumeTransformer` for the purpose of keeping audio data
+    in memory. This gives us the option to download the file while streaming it to the
+    client at the same time, without needing to fetch from YouTube twice.
+    """
+
+    def __init__(
+        self,
+        source: discord.FFmpegPCMAudio,
+        *,
+        volume=1.0,
+        loop: asyncio.AbstractEventLoop = None,
+        metadata: Mapping[str, Any] = None,
+        download=False,
+    ):
         super().__init__(source, volume)
-        self.data = data
-        self.title = data.get("title")
-        self.url = data.get("url")
+        self.source = source
+        self.loop = loop or asyncio.get_event_loop()
+        self.metadata = metadata
+        self.is_stream_ready = False
+        self.is_download_ready = False
+        self._audio_buffer: List[bytes] = []
+        self._audio_buffer_index = -1
+
+        if download:
+            self.download_task = self.loop.create_task(self.start_download())
 
     @classmethod
-    async def from_url(cls, url, *, loop=None, stream=False):
+    async def from_query(cls, query: str, *, loop: asyncio.AbstractEventLoop = None):
+        """Instantiate `YTDLSource` from a generic query or URL."""
+        logger.debug(f"Fetching metadata for query: {query}")
+        start_time = perf_counter()
+
+        ytdl = youtube_dl.YoutubeDL(YTDL_FORMAT_OPTIONS)
         loop = loop or asyncio.get_event_loop()
-
         data = await loop.run_in_executor(
-            None, lambda: ytdl.extract_info(url, download=not stream)
+            None, lambda: ytdl.extract_info(query, download=False)
         )
-
         if "entries" in data:
             data = data["entries"][0]
 
-        filename = data["url"] if stream else ytdl.prepare_filename(data)
-        return cls(discord.FFmpegPCMAudio(filename, **ffmpeg_options), data=data)
+        end_time = perf_counter()
+        logger.debug(
+            f"Fetched metadata for query: {query} (took {end_time - start_time:0.2f} seconds)"
+        )
+
+        return cls(
+            discord.FFmpegPCMAudio(data["url"], **ffmpeg_options),
+            loop=loop,
+            metadata=data,
+        )
 
     @classmethod
-    def from_file(cls, filename):
+    def from_file(cls, filename: str | BufferedIOBase):
         return cls(
             discord.FFmpegPCMAudio(filename, **ffmpeg_options), data={"duration": 1}
         )
+
+    async def wait_for_stream_ready_state(self):
+        """Coroutine that resolves when the source is ready to start streaming."""
+        while self.is_stream_ready is not True:
+            await asyncio.sleep(0)
+        return True
+
+    async def wait_for_download_ready_state(self):
+        """Coroutine that resolves when the source is fully downloaded."""
+        while self.is_download_ready is not True:
+            await asyncio.sleep(0)
+        return True
+
+    async def start_download(self):
+        """Long running coroutine that starts downloading bytes from the audio source
+        and keeps them in an internal buffer. Updates internal `is_stream_ready` state
+        to `True` once the buffer has more than 1 second of audio data, and
+        `is_download_ready` state to `True` once the audio has been fully downloaded.
+        """
+        title = self.metadata["title"]
+        logger.debug(f"Starting download for: {title}")
+        start_time = perf_counter()
+
+        total_ms = 0
+        while True:
+            # 20ms worth of 16-bit 48KHz stereo PCM (about 3,840 bytes / frame)
+            bytes = self.source.read()
+            if bytes == b"":
+                break
+            total_ms += 20
+            self._audio_buffer.append(bytes)
+
+            if total_ms >= 1000:
+                self.is_stream_ready = True
+
+            await asyncio.sleep(0)
+
+        end_time = perf_counter()
+        logger.info(
+            f"Finished downloading {title} with {len(self._audio_buffer)} total bytes "
+            f"and {total_ms / 1000} seconds (took {end_time - start_time:0.2f} "
+            "seconds)"
+        )
+
+    def write_buffer_to_file(self, filename: str = None) -> str:
+        """Writes the current audio buffer to a file. Internal `is_stream_ready` state
+        must be `True`.
+        """
+        if not self.is_download_ready:
+            raise Exception("download not yet available")
+
+        # TODO: sanitize filename -> lowercase + remove special chars
+        filename = filename or f"downloads/{self.metadata['id']}.mp3"
+        logger.debug(f"Saving to downloads directory...")
+        segment = AudioSegment(
+            self._audio_buffer.copy(),
+            sample_width=2,
+            frame_rate=48000,
+            channels=2,
+        )
+        segment.export(filename, format="mp3")
+        return filename
+
+    def get_progress(self) -> float:
+        """Returns a float (0.0 through 1.0) indicating how much audio data has been
+        read by the buffer.
+        """
+        if not self.is_stream_ready:
+            raise Exception("stream not yet ready")
+
+        if self._audio_buffer_index <= 0:
+            return 0.0
+
+        return self._audio_buffer_index + 1 / len(self._audio_buffer)
+
+    def get_time_elapsed(self) -> float:
+        """Returns number of miliseconds worth of audio data that has been read from the
+        buffer.
+        """
+        raise NotImplementedError()
+
+    def get_time_remaining(self) -> float:
+        """Returns number of miliseconds worth of audio data remaining in the audio
+        buffer.
+        """
+        bytes_remaining = len(self._audio_buffer) - self._audio_buffer_index + 1
+        return bytes_remaining * 20
+
+    def read(self) -> bytes:
+        if not self.is_stream_ready:
+            raise Exception("stream not yet ready")
+
+        self._audio_buffer_index += 1
+        data = self._audio_buffer[self._audio_buffer_index]
+
+        return data

--- a/lib/ytdl.py
+++ b/lib/ytdl.py
@@ -122,6 +122,18 @@ class YTDLSource(discord.PCMVolumeTransformer):
                 err_msg = "ytdl returned a playlist extraction with no entries"
                 raise Exception(err_msg)
 
+            # TODO: I added this line as a temporary fix to queries that result in a
+            # playlist with only one song in them, resulting in a "Added a playlist
+            # with 1 songs to the queue" message sent to the channel
+            # this line should be removed and we need to add separate playlist
+            # metadata so our discord music cog can send more descriptive messages
+            if len(entries) == 1:
+                return YTDLSource(
+                    discord.FFmpegPCMAudio(entries[0]["url"], **ffmpeg_options),
+                    metadata=entries[0],
+                    loop=loop,
+                )
+
             return [
                 YTDLSource(
                     discord.FFmpegPCMAudio(entry["url"], **ffmpeg_options),

--- a/lib/ytdl.py
+++ b/lib/ytdl.py
@@ -462,9 +462,6 @@ class YTDLSourcesController(discord.AudioSource):
 
     def pop(self, index: int = -1):
         """Remove and cleanup a source from the queue (default last)."""
-        # TODO: what if the player is currently playing this song, and then we pop it,
-        # and there are no songs after this one. the controller will try to play at an
-        # index that doesn't exist. it SHOULD just stop playing
         if index is None:
             index = -1
         source = self.sources.pop(index)

--- a/lib/ytdl.py
+++ b/lib/ytdl.py
@@ -80,6 +80,13 @@ class YTDLSource(discord.PCMVolumeTransformer):
         self.download_task = None
 
     @property
+    def full_title(self):
+        """Returns the full artist & title of the song (e.g. "Eminem - Mockingbird")"""
+        title = self.metadata["title"]
+        artist = self.metadata.get("artist") or self.metadata["uploader"]
+        return f"{artist} - {title}".strip()
+
+    @property
     def is_downloading(self) -> bool:
         return not self.download_task is None
 

--- a/lib/ytdl.py
+++ b/lib/ytdl.py
@@ -126,6 +126,7 @@ class YTDLSourcesController(discord.AudioSource):
     # def pop(self, index: int):
     #     """Remove a source from the queue."""
 
+    # TODO: next/back commands should reset the song and play from the beginning
     def next(self):
         """Sets the current source index to the next source in the queue."""
         self.current_source_index += 1


### PR DESCRIPTION
This is a PR to revamp the current music commands. They work for the most part, but completely break under certain circumstances (I think anytime it tries playing a non-youtube URL or a very big playlist). I also want to move the commands over to slash commands, since they're cleaner as well as add a bunch of new features that would bring our bot almost on-par with other music bots.

Here's a full list of the planned commands that I'm adding/refactoring as part of this PR:
- `/yt play <str>` --> plays a youtube video or song from a generic query (e.g. "adele set fire to the rain") or a URL
- `/yt stop` --> stops the player and disconnects the bot from the voice channel
- `/yt grab` --> downloads the current playing song and sends a file to the Discord channel
- `/yt volume <float>` --> change the player volume
- `/yt pause` --> pause the player
- `/yt resume` --> resume the player
- `/yt queue` --> lists the songs in the current queue
- `/yt pop <int>` --> removes a song from the queue
- `/yt next` --> starts playing the next song in the queue
- `/yt back` --> starts playing the previous song in the queue
- `/yt scrub <int>` --> goes x number of seconds back or forward in the current playing
- `/yt slowed` --> toggles a slowed effect on the current playing song
- `/yt spedup` --> toggles a spedup effect on the current playing song
- `/yt repeat` --> toggles repeating the queue when it ends or just the current playing song
- `/yt progress` --> shows the progress of the current playing song by sending something like this `...............|........ 2:15 / 3:22` (this one might make more sense as something added on to the response of the `play` command)
- `/yt mp3 <str>` --> downloads a song and sends a file to the discord channel (similar to the "grab" command only this one doesn't need to be in the channel playing a song)
- `/yt mp4 <str>` --> downloads a song and the music video and sends the file to the discord channel

**TODO:**
- [x] Add support for playlists
- [ ] Add support for live streams (this was something that was already supported before, but won't work anymore with the current changes)
- [ ] Convert all the commands over to slash commands
- [x] Finish `play` command
- [x] Finish `stop` command
- [x] Finish `grab` command
- [x] Finish `volume` command
- [x] Finish `pause` command
- [x] Finish `resume` command
- [x] Finish `queue` command
- [x] Finish `pop` command
- [x] Finish `next` command
- [x] Finish `back` command
- [ ] Finish `scrub` command
- [ ] Finish `slowed` command
- [ ] Finish `spedup` command
- [ ] Finish `mp3` command
- [x] ~~Finish `mp4` command~~ (will be implemented in a future release)
- [ ] Finish `repeat` command
- [ ] Finish `progress` command
- [ ] Address any remaining TODOs in the code